### PR TITLE
Remove utf8ToSqueak call from jsonFromResponse, because Webresponse a…

### DIFF
--- a/packages/TogglClient-Core.package/TogglJsonParser.class/class/jsonFromResponse..st
+++ b/packages/TogglClient-Core.package/TogglJsonParser.class/class/jsonFromResponse..st
@@ -1,3 +1,3 @@
 parsing
 jsonFromResponse: aResponse
-	^ Json readFrom: aResponse content utf8ToSqueak readStream
+	^ Json readFrom: aResponse content readStream

--- a/packages/TogglClient-Core.package/TogglJsonParser.class/methodProperties.json
+++ b/packages/TogglClient-Core.package/TogglJsonParser.class/methodProperties.json
@@ -1,6 +1,6 @@
 {
 	"class" : {
 		"createTimeEntryFromJson:" : "THH 6/2/2019 19:07",
-		"jsonFromResponse:" : "JZY 5/26/2019 19:43" },
+		"jsonFromResponse:" : "THH 6/17/2019 15:21" },
 	"instance" : {
 		 } }


### PR DESCRIPTION
…lready converts from UTF-8 to Squeak if an UTF-8 encoded Response is given.