### PR TITLE
Add parsing to Local Time when calling from API. Add Tests. 

### DIFF
--- a/packages/TogglClient-Core.package/TogglJsonParser.class/class/createTimeEntryFromJson..st
+++ b/packages/TogglClient-Core.package/TogglJsonParser.class/class/createTimeEntryFromJson..st
@@ -8,9 +8,9 @@ createTimeEntryFromJson: json
 		ifNil: [timeEntry description: 'no description']
 		ifNotNil: [timeEntry description: (json at: 'description')].
 	(json at: 'start') ifNotNil: [
-		timeEntry startDateAndTime: (DateAndTime fromString: (json at: 'start'))].
+		timeEntry startDateAndTime: (DateAndTime fromString: (json at: 'start')) asLocal].
 	(json at: 'stop') ifNotNil: [
-		timeEntry stopDateAndTime: (DateAndTime fromString: (json at: 'stop'))].
+		timeEntry stopDateAndTime: (DateAndTime fromString: (json at: 'stop')) asLocal].
 	(json at: 'wid') ifNotNil: [
 		timeEntry wid: (json at: 'wid')].
 	

--- a/packages/TogglClient-Core.package/TogglJsonParser.class/methodProperties.json
+++ b/packages/TogglClient-Core.package/TogglJsonParser.class/methodProperties.json
@@ -1,7 +1,7 @@
 {
 	"class" : {
 		"createJsonFromTimeEntry:" : "JZY 6/19/2019 12:11",
-		"createTimeEntryFromJson:" : "JZY 6/17/2019 18:36",
+		"createTimeEntryFromJson:" : "THH 6/20/2019 13:28",
 		"jsonFromResponse:" : "THH 6/17/2019 15:21" },
 	"instance" : {
 		 } }

--- a/packages/TogglClient-Tests.package/ToggIJsonParserTests.class/instance/testCreateTimeEntryFromJsonWithDifferentTimeZoneThanLocal.st
+++ b/packages/TogglClient-Tests.package/ToggIJsonParserTests.class/instance/testCreateTimeEntryFromJsonWithDifferentTimeZoneThanLocal.st
@@ -1,0 +1,7 @@
+tests
+testCreateTimeEntryFromJsonWithDifferentTimeZoneThanLocal
+	| timeEntry |
+	
+	timeEntry := TogglJsonParser createTimeEntryFromJson: (Json readFrom: noDescriptionJson readStream).
+	self assert: DateAndTime localOffset equals: timeEntry startDateAndTime offset. 
+	self assert: DateAndTime localOffset equals: timeEntry stopDateAndTime offset. 

--- a/packages/TogglClient-Tests.package/ToggIJsonParserTests.class/methodProperties.json
+++ b/packages/TogglClient-Tests.package/ToggIJsonParserTests.class/methodProperties.json
@@ -4,4 +4,5 @@
 	"instance" : {
 		"setUp" : "JZY 6/18/2019 20:18",
 		"testCreateTimeEntryFromJsonReturnsTimeEntry" : "THH 6/4/2019 10:49",
-		"testCreateTimeEntryFromJsonReturnsTimeEntryWithoutDescription" : "THH 6/2/2019 19:05" } }
+		"testCreateTimeEntryFromJsonReturnsTimeEntryWithoutDescription" : "THH 6/2/2019 19:05",
+		"testCreateTimeEntryFromJsonWithDifferentTimeZoneThanLocal" : "THH 6/20/2019 13:36" } }

--- a/packages/TogglClient-Tests.package/ToggIJsonParserTests.class/properties.json
+++ b/packages/TogglClient-Tests.package/ToggIJsonParserTests.class/properties.json
@@ -8,8 +8,7 @@
 	"instvars" : [
 		"testTimeEntry",
 		"testJson",
-		"noDescriptionJson",
-		"specialCharacterJson" ],
+		"noDescriptionJson" ],
 	"name" : "ToggIJsonParserTests",
 	"pools" : [
 		 ],


### PR DESCRIPTION
Seems that Toggl API always returns UTC 00:00 - differing from their API documentation.